### PR TITLE
Harden SSL handling and add diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ Thumbs.db
 # === Logs and dumps ===
 *.log
 
+# === Local certificates ===
+certs/
+*.pem
+*.crt
+
 # === Jupyter/IPython ===
 .ipynb_checkpoints/
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Installation
 1. Unzip the `rapidbotz-bootstrapper` package to a local folder (e.g., `C:\Rapidbotz`).
 2. Double-click `run_bootstrapper.bat`.
 
+The launcher mirrors all output to the console and saves a timestamped log (`bootstrapper-YYYYMMDD-HHMMSS.log`) in the same folder for troubleshooting.
+
 The first time you run it, it will:
 - Extract embedded Python
 - Install pip (automatically)
@@ -36,7 +38,7 @@ The first time you run it, it will:
 
 First-Time Setup
 ----------------
-The first time you run `bootstrapper.bat`, it will:
+The first time you run `run_bootstrapper.bat`, it will:
 1. Check for Python, Git, and Java (install them if missing—see Requirements).
 2. Ask for your credentials:
    - GitHub PAT (needs 'repo' and 'write:public_key' scopes).
@@ -61,7 +63,7 @@ ACTION REQUIRED: Authorize the SSH key for SSO in GitHub:
 Running the Agent
 -----------------
 After the first setup:
-- Double-click `bootstrapper.bat` anytime to update the repository and restart the agent.
+- Double-click `run_bootstrapper.bat` anytime to update the repository and restart the agent.
 - It uses your saved credentials and SSH key—no need to re-enter anything unless IT changes your details.
 
 What It Does
@@ -77,11 +79,92 @@ Stopping the Agent
 
 Troubleshooting
 ---------------
-- **"Python/Git/Java not found"**: Install the missing tool (see Requirements) and rerun.
-- **"Failed to clone repository"**: 
+
+### Corporate TLS / Netskope: trusting the inspected chain
+If your corporate network performs TLS inspection (e.g., Netskope), Python’s default CA bundle (from `certifi`) will not trust
+the injected corporate root. You have three secure ways to supply the correct CA to the tool:
+
+**Option A: Use the standard Requests env var (recommended, per-user)**
+
+1. Obtain the approved corporate CA bundle (PEM) from IT/SecOps. **Do not commit it to this repo.**
+2. Save it locally, e.g.:
+   ```
+   C:\certs\csaa_netskope_combined.pem
+   ```
+3. Set the environment variable:
+   - **PowerShell (current session):**
+     ```powershell
+     $Env:REQUESTS_CA_BUNDLE = 'C:\certs\csaa_netskope_combined.pem'
+     ```
+   - **CMD (persist for future sessions):**
+     ```cmd
+     setx REQUESTS_CA_BUNDLE "C:\certs\csaa_netskope_combined.pem"
+     ```
+4. Run the bootstrapper normally. `requests` will automatically use this bundle.
+
+**Option B: Tool-specific flag/env**
+
+- CLI flag:
+  ```cmd
+  python rapidbotz_bootstrapper.py --ca-bundle C:\certs\csaa_netskope_combined.pem
+  ```
+- Or env var:
+  ```cmd
+  setx RAPIDBOTZ_CA_BUNDLE "C:\certs\csaa_netskope_combined.pem"
+  ```
+This takes precedence over `REQUESTS_CA_BUNDLE`.
+
+**Option C: Temporary escape hatch**
+
+```cmd
+python rapidbotz_bootstrapper.py --insecure
+```
+This disables certificate verification. Use **only** to confirm root cause locally. Do **not** use in CI/CD or production.
+
+#### Verifying your setup
+Run:
+```cmd
+python diagnose_ssl.py
+```
+This prints:
+- Effective CA bundle (which of: `--ca-bundle`, `RAPIDBOTZ_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE`, or `certifi`)
+- Proxies (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`)
+- Python/OpenSSL/requests versions
+- A certificate chain summary for `https://api.github.com` and whether TLS inspection is likely
+
+#### Team rollout guidance
+- **Do not share** the PEM externally or commit it. Store locally per user.
+- Prefer an **internal distribution page** (Confluence/SharePoint) or IT portal where teammates can download the approved `csaa_netskope_combined.pem` and follow the steps above.
+- If the corporate CA rotates, update the internal distribution and notify users to refresh their local file.
+
+### Proxies
+The tool respects `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. You can also pass `--proxy`.
+
+### Ignore files
+Add these patterns to keep local certs out of source control:
+```
+certs/
+*.pem
+*.crt
+```
+
+## Common Errors
+
+- `SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] self-signed certificate in certificate chain`
+  - Usually indicates the corporate root CA isn’t trusted. Follow the steps above.
+  - If you must unblock quickly for local testing, use `--insecure` (temporary only).
+
+Decision tree:
+1) Run python diagnose_ssl.py
+2) If it reports “LIKELY TLS inspection”, configure Option A or B above.
+3) Re-run your command.
+4) Only if still blocked: verify proxy settings, then open an internal ticket with the diagnose output attached.
+
+-- **"Python/Git/Java not found"**: Install the missing tool (see Requirements) and rerun.
+-- **"Failed to clone repository"**:
    - Check your internet connection.
    - Ensure the SSH key is authorized (Settings > SSH and GPG keys > Configure SSO).
    - Contact IT if the error persists.
-- **"Agent file not found"**: The repository might not have cloned correctly—see above.
-- **"Database in use"**: The script should fix this automatically; if not, delete `C:/cfg-mobilitas/BotzAgent/db/BotzAgent.lock.db` and retry.
-- **Still stuck?**: Take a screenshot of the error and email IT.
+-- **"Agent file not found"**: The repository might not have cloned correctly—see above.
+-- **"Database in use"**: The script should fix this automatically; if not, delete `C:/cfg-mobilitas/BotzAgent/db/BotzAgent.lock.db` and retry.
+-- **Still stuck?**: Take a screenshot of the error and email IT.

--- a/diagnose_ssl.py
+++ b/diagnose_ssl.py
@@ -1,0 +1,100 @@
+import argparse
+import os
+import socket
+import ssl
+import sys
+import tempfile
+from datetime import datetime
+
+import certifi
+import requests
+import urllib3
+
+from rbz.http import Options, resolve_ca_bundle, build_session
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Diagnose SSL configuration")
+    parser.add_argument("--ca-bundle", help="Path to a custom CA bundle")
+    parser.add_argument("--proxy", help="Proxy URL for both HTTP and HTTPS")
+    parser.add_argument("--insecure", action="store_true", help="Disable TLS verification")
+    return parser.parse_args()
+
+
+def print_versions():
+    print(f"Python: {sys.version}")
+    print(f"OpenSSL: {ssl.OPENSSL_VERSION}")
+    print(f"requests: {requests.__version__}")
+    print(f"urllib3: {urllib3.__version__}")
+    print(f"certifi: {certifi.__version__}")
+
+
+def print_env_proxies():
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        print(f"{var}={os.environ.get(var)}")
+
+
+def describe_ca_source(options: Options, ca_path: str) -> str:
+    if options.ca_bundle:
+        return f"--ca-bundle ({ca_path})"
+    if os.environ.get("RAPIDBOTZ_CA_BUNDLE"):
+        return f"RAPIDBOTZ_CA_BUNDLE ({ca_path})"
+    if os.environ.get("REQUESTS_CA_BUNDLE"):
+        return f"REQUESTS_CA_BUNDLE ({ca_path})"
+    if os.environ.get("SSL_CERT_FILE"):
+        return f"SSL_CERT_FILE ({ca_path})"
+    return f"certifi ({ca_path})"
+
+
+def fetch_github_cert(session: requests.Session):
+    host = "api.github.com"
+    try:
+        ctx = ssl.create_default_context()
+        if session.verify and isinstance(session.verify, str):
+            ctx.load_verify_locations(session.verify)
+        with ctx.wrap_socket(socket.socket(), server_hostname=host) as s:
+            s.settimeout(5)
+            s.connect((host, 443))
+            der = s.getpeercert(True)
+    except Exception as e:
+        print(f"Error fetching certificate: {e}")
+        return False
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write(der)
+    tmp.close()
+    cert = ssl._ssl._test_decode_cert(tmp.name)
+    os.unlink(tmp.name)
+    subject = dict(x[0] for x in cert["subject"])
+    issuer = dict(x[0] for x in cert["issuer"])
+    sans = [san[1] for san in cert.get("subjectAltName", [])]
+    not_before = cert.get("notBefore")
+    not_after = cert.get("notAfter")
+    print("Certificate subject:", subject)
+    print("Certificate issuer:", issuer)
+    print("Subject Alt Names:", sans)
+    print("Validity:", not_before, "to", not_after)
+    issuer_str = " ".join(issuer.values())
+    if "Netskope" in issuer_str or "Corporate" in issuer_str:
+        print("LIKELY TLS inspection in place")
+        return False
+    return True
+
+
+def main():
+    args = parse_args()
+    proxies = {"http": args.proxy, "https": args.proxy} if args.proxy else None
+    options = Options(ca_bundle=args.ca_bundle, proxies=proxies, insecure=args.insecure)
+    session = build_session(options)
+
+    print_versions()
+    print("Effective CA bundle:", describe_ca_source(options, resolve_ca_bundle(options)))
+    print_env_proxies()
+    print("ssl.get_default_verify_paths():", ssl.get_default_verify_paths())
+
+    ok = fetch_github_cert(session)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/rapidbotz_bootstrapper.py
+++ b/rapidbotz_bootstrapper.py
@@ -2,11 +2,14 @@ import os
 import subprocess
 import sys
 import json
+import argparse
 from pathlib import Path
 import requests
 import time
 import keyring
 import getpass
+
+from rbz.http import Options, build_session
 
 # === LOAD CONFIG ===
 DEFAULT_CONFIG = {
@@ -39,6 +42,24 @@ SERVICE_NAME = "Rapidbotz"
 SSH_DIR = Path.home() / ".ssh"
 SSH_KEY = SSH_DIR / "id_ed25519"
 
+# === HTTP OPTIONS ===
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ca-bundle", help="Path to a custom CA bundle")
+    parser.add_argument("--proxy", help="Proxy URL for both HTTP and HTTPS")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS verification (unsafe; for local testing only)",
+    )
+    return parser.parse_args()
+
+
+args = parse_args()
+_proxies = {"http": args.proxy, "https": args.proxy} if args.proxy else None
+HTTP_OPTIONS = Options(ca_bundle=args.ca_bundle, proxies=_proxies, insecure=args.insecure)
+SESSION = build_session(HTTP_OPTIONS)
+
 # === CREDENTIAL MANAGEMENT ===
 def get_credential(key, prompt):
     credential = keyring.get_password(SERVICE_NAME, key)
@@ -66,7 +87,7 @@ def generate_ssh_key(email):
         return True  # Indicate a new key was generated
     return False  # No new key generated
 
-def add_ssh_key_to_github(token, public_key_path):
+def add_ssh_key_to_github(token, public_key_path, session: requests.Session):
     with open(public_key_path, "r") as f:
         public_key = f.read().strip()
     api_url = "https://api.github.com/user/keys"
@@ -75,7 +96,7 @@ def add_ssh_key_to_github(token, public_key_path):
         "title": f"Rapidbotz-{time.strftime('%Y%m%d-%H%M%S')}",
         "key": public_key
     }
-    response = requests.post(api_url, headers=headers, json=data)
+    response = session.post(api_url, headers=headers, json=data, timeout=HTTP_OPTIONS.timeout)
     if response.status_code == 201:
         print("SSH key added to GitHub successfully!")
         return True  # New key added
@@ -101,18 +122,20 @@ RAPIDBOTZ_SECRET = get_credential("RAPIDBOTZ_SECRET", "Please enter your Rapidbo
 
 # Generate and upload SSH key if needed
 new_key_generated = generate_ssh_key(GITHUB_EMAIL)
-new_key_added = add_ssh_key_to_github(GITHUB_TOKEN, SSH_KEY.with_suffix(".pub"))
+new_key_added = add_ssh_key_to_github(GITHUB_TOKEN, SSH_KEY.with_suffix(".pub"), SESSION)
 if new_key_generated or new_key_added:
     wait_for_sso_authorization()
 
 # === FUNCTIONS ===
-def get_latest_remote_commit():
+def get_latest_remote_commit(session: requests.Session):
     api_url = f"https://api.github.com/repos/{GITHUB_REPO}/commits/{BRANCH}"
     headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {GITHUB_TOKEN}"}
     try:
-        response = requests.get(api_url, headers=headers, timeout=10)
+        response = session.get(api_url, headers=headers, timeout=HTTP_OPTIONS.timeout)
         response.raise_for_status()
         return response.json()["sha"]
+    except requests.exceptions.SSLError:
+        raise
     except requests.RequestException as e:
         print(f"WARNING: Could not check for updates (network error: {e}). Proceeding anyway...")
         return None
@@ -156,7 +179,7 @@ if not repo_path.exists():
         sys.exit(1)
 else:
     print(f"Found existing repository at {LOCAL_REPO_DIR}. Checking for updates...")
-    remote_commit = get_latest_remote_commit()
+    remote_commit = get_latest_remote_commit(SESSION)
     local_commit = get_latest_local_commit(LOCAL_REPO_DIR)
     if remote_commit and local_commit and remote_commit == local_commit:
         print("Repository is already up to date.")

--- a/rbz/__init__.py
+++ b/rbz/__init__.py
@@ -1,0 +1,3 @@
+from .http import Options, build_session, resolve_ca_bundle
+
+__all__ = ["Options", "build_session", "resolve_ca_bundle"]

--- a/rbz/http.py
+++ b/rbz/http.py
@@ -1,0 +1,73 @@
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import certifi
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+@dataclass
+class Options:
+    timeout: float = 30.0
+    ca_bundle: Optional[str] = None
+    proxies: Optional[Dict[str, str]] = None
+    insecure: bool = False
+    retries: int = 3
+    backoff_factor: float = 0.5
+    user_agent: str = "rapidbotz-bootstrapper/1.0"
+    extra_headers: Optional[Dict[str, str]] = None
+
+
+def resolve_ca_bundle(options: Options):
+    if options.insecure:
+        return False
+    if options.ca_bundle:
+        return options.ca_bundle
+    env = os.getenv("RAPIDBOTZ_CA_BUNDLE")
+    if env:
+        return env
+    env = os.getenv("REQUESTS_CA_BUNDLE")
+    if env:
+        return env
+    env = os.getenv("SSL_CERT_FILE")
+    if env:
+        return env
+    return certifi.where()
+
+
+def build_session(options: Options) -> requests.Session:
+    session = requests.Session()
+
+    retry = Retry(
+        total=options.retries,
+        connect=options.retries,
+        read=options.retries,
+        status=options.retries,
+        backoff_factor=options.backoff_factor,
+        status_forcelist=[502, 503, 504],
+        allowed_methods={"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
+    session.verify = resolve_ca_bundle(options)
+
+    if options.proxies:
+        session.proxies.update(options.proxies)
+
+    session.headers["User-Agent"] = options.user_agent
+    if options.extra_headers:
+        session.headers.update(options.extra_headers)
+    _orig_request = session.request
+    default_timeout = options.timeout
+
+    def _request_with_timeout(method, url, **kwargs):
+        if "timeout" not in kwargs or kwargs["timeout"] is None:
+            kwargs["timeout"] = default_timeout
+        return _orig_request(method, url, **kwargs)
+
+    session.request = _request_with_timeout
+    return session

--- a/run_bootstrapper.bat
+++ b/run_bootstrapper.bat
@@ -1,72 +1,106 @@
 @echo off
 setlocal
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+echo Rapidbotz Bootstrapper
 
-:: ==== Friendly Header ====
-echo --------------------------------------------
-echo   Rapidbotz Bootstrapper Launcher
-echo   Version 1.0 (Embedded Python Mode)
-echo --------------------------------------------
+:: timestamped log
+for /f %%i in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd-HHmmss"') do set TIMESTAMP=%%i
+set "LOGFILE=bootstrapper-%TIMESTAMP%.log"
+echo Logging to %LOGFILE%
+> "%LOGFILE%" echo Rapidbotz bootstrapper log %TIMESTAMP%
 
-:: ==== Optionally set env vars ====
-:: Uncomment these if you're running in a restricted environment
-:: set GITHUB_PAT=your_github_pat_here
-:: set GITHUB_EMAIL=your_email@yourdomain.com
-:: set RAPIDBOTZ_SECRET=BZ::firstname.lastname::xxxxxxxxxxxxxxxxxxxx
+set "PY_DIR=python"
+set "PY_EXE=%PY_DIR%\python.exe"
+set "WHEELS_DIR=wheels"
+set "REQS=requirements.txt"
 
-:: ==== Extract Embedded Python ====
-IF NOT EXIST python\python.exe (
-    echo Extracting embedded Python...
-    mkdir python >nul 2>&1
-    powershell -NoProfile -Command "Expand-Archive -Path 'python-3.13.2-embed-amd64.zip' -DestinationPath 'python' -Force"
-)
-
-IF NOT EXIST python\python.exe (
-    echo ERROR: python.exe not found after extraction. Something went wrong.
-    pause
+:: extract embedded Python if missing
+if not exist "%PY_EXE%" (
+  echo Extracting embedded Python...
+  mkdir "%PY_DIR%" >nul 2>&1
+  powershell -NoProfile -Command "Expand-Archive -Path 'python-3.13.2-embed-amd64.zip' -DestinationPath '%PY_DIR%' -Force" >>"%LOGFILE%" 2>&1
+  if errorlevel 1 (
+    echo Failed to extract Python. See log: %LOGFILE%
     exit /b 1
+  )
 )
 
-:: ==== Install pip if needed ====
-IF NOT EXIST python\Scripts\pip.exe (
-    echo Installing pip...
-    if EXIST get-pip.py (
-        python\python.exe get-pip.py
-    ) else (
-        echo ERROR: get-pip.py is missing!
-        pause
-        exit /b 1
+:: ensure python._pth enables site and stdlib zip
+set "PYZIP=python313.zip"
+(
+  echo %PYZIP%
+  echo %SCRIPT_DIR%
+  echo .
+  echo import site
+)>"%PY_DIR%\python._pth"
+
+:: ensure pip is available
+"%PY_EXE%" -m pip --version >>"%LOGFILE%" 2>&1
+if errorlevel 1 (
+  call :clean_broken_pip
+  echo Installing pip...
+  "%PY_EXE%" get-pip.py >>"%LOGFILE%" 2>&1
+  if errorlevel 1 (
+    echo Failed to install pip. See log: %LOGFILE%
+    exit /b 1
+  )
+)
+
+:: install dependencies (prefer local wheels)
+echo Installing dependencies...
+call :install_deps_offline_first
+if errorlevel 1 (
+  echo Failed to install dependencies. See log: %LOGFILE%
+  exit /b 1
+)
+
+:: run bootstrapper
+echo - Running setup...
+set "PYTHONPATH=%SCRIPT_DIR%;%PYTHONPATH%"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$ErrorActionPreference='Continue'; cmd /c \"\"%PY_EXE%\" rapidbotz_bootstrapper.py 2^>^&1\" | Tee-Object -FilePath '%LOGFILE%' -Append; exit $LASTEXITCODE"
+if errorlevel 1 (
+  echo ERROR: Setup failed. See %LOGFILE%
+  exit /b 1
+)
+
+echo Success.
+exit /b 0
+
+:install_deps_offline_first
+setlocal ENABLEDELAYEDEXPANSION
+set "DO_OFFLINE=0"
+if exist "%WHEELS_DIR%" (
+  dir /b "%WHEELS_DIR%\*.whl" >nul 2>&1 && set "DO_OFFLINE=1"
+)
+if "!DO_OFFLINE!"=="1" (
+  echo Using local wheels
+  if exist "%REQS%" (
+    "%PY_EXE%" -m pip install --no-index --find-links="%WHEELS_DIR%" -r "%REQS%" --no-warn-script-location >>"%LOGFILE%" 2>&1
+    if errorlevel 1 (endlocal & exit /b 1)
+  ) else (
+    rem Expand the wheel list ourselves (pip does not expand *.whl in .bat)
+    set "PKGS="
+    for %%F in ("%WHEELS_DIR%\*.whl") do (
+      set "PKGS=!PKGS! \"%%~fF\""
     )
+    if not defined PKGS (
+      echo ERROR: No .whl files found in "%WHEELS_DIR%".
+      endlocal & exit /b 1
+    )
+    "%PY_EXE%" -m pip install --no-index --find-links="%WHEELS_DIR%" !PKGS! --no-warn-script-location >>"%LOGFILE%" 2>&1
+    if errorlevel 1 (endlocal & exit /b 1)
+  )
+) else if exist "%REQS%" (
+  "%PY_EXE%" -m pip install -r "%REQS%" --no-warn-script-location >>"%LOGFILE%" 2>&1
+  if errorlevel 1 (endlocal & exit /b 1)
+) else (
+  echo No requirements.txt found; skipping dependency install >>"%LOGFILE%"
 )
+endlocal & exit /b 0
 
-:: ==== Check for Git ====
-echo Checking for Git...
-where git >nul 2>&1
-IF %ERRORLEVEL% NEQ 0 (
-    echo ERROR: Git not found! Install from git-scm.com.
-    pause
-    exit /b 1
-)
-
-:: ==== Check for Java ====
-echo Checking for Java...
-java -version >nul 2>&1
-IF %ERRORLEVEL% NEQ 0 (
-    echo ERROR: Java not found! Install from java.com.
-    pause
-    exit /b 1
-)
-
-:: ==== Install Python dependencies ====
-echo Installing required Python packages...
-python\python.exe -m pip install --upgrade pip --no-warn-script-location
-python\python.exe -m pip install -r requirements.txt --no-warn-script-location
-
-:: ==== Run the Script ====
-echo.
-echo Starting Rapidbotz setup...
-python\python.exe rapidbotz_bootstrapper.py
-
-:: ==== Finish ====
-echo.
-echo Setup complete! Press any key to exit.
-pause
+:clean_broken_pip
+for /d %%D in ("%PY_DIR%\Lib\site-packages\pip-*.dist-info") do rmdir /s /q "%%~fD" >>"%LOGFILE%" 2>&1
+del /q "%PY_DIR%\Scripts\pip*.exe" >nul 2>&1
+exit /b 0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from pathlib import Path
+
+import certifi
+import pytest
+import requests
+
+# Ensure package import
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rbz import Options, resolve_ca_bundle, build_session
+
+
+def test_resolve_ca_bundle_precedence(monkeypatch, tmp_path):
+    cli = tmp_path / "cli.pem"
+    env = tmp_path / "env.pem"
+    req = tmp_path / "req.pem"
+    ssl_file = tmp_path / "ssl.pem"
+    for p in (cli, env, req, ssl_file):
+        p.write_text("cert")
+
+    opts = Options(ca_bundle=str(cli))
+    monkeypatch.setenv("RAPIDBOTZ_CA_BUNDLE", str(env))
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(req))
+    monkeypatch.setenv("SSL_CERT_FILE", str(ssl_file))
+    assert resolve_ca_bundle(opts) == str(cli)
+
+    opts = Options()
+    monkeypatch.setenv("RAPIDBOTZ_CA_BUNDLE", str(env))
+    assert resolve_ca_bundle(opts) == str(env)
+
+    monkeypatch.delenv("RAPIDBOTZ_CA_BUNDLE")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(req))
+    assert resolve_ca_bundle(opts) == str(req)
+
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE")
+    monkeypatch.setenv("SSL_CERT_FILE", str(ssl_file))
+    assert resolve_ca_bundle(opts) == str(ssl_file)
+
+    monkeypatch.delenv("SSL_CERT_FILE")
+    assert resolve_ca_bundle(opts) == certifi.where()
+
+
+def test_insecure_verify_false():
+    opts = Options(insecure=True)
+    session = build_session(opts)
+    assert session.verify is False
+
+
+def test_default_timeout(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):
+        captured['timeout'] = kwargs.get('timeout')
+        class Dummy:
+            status_code = 200
+            def close(self):
+                pass
+        return Dummy()
+
+    monkeypatch.setattr(requests.Session, 'request', fake_request, raising=False)
+    opts = Options(timeout=12)
+    session = build_session(opts)
+    session.request('GET', 'http://example.com')
+    assert captured['timeout'] == 12
+    session.request('GET', 'http://example.com', timeout=1)
+    assert captured['timeout'] == 1


### PR DESCRIPTION
## Summary
- mirror bootstrapper execution output to console and log via PowerShell tee while keeping clean UX
- wrap Requests session to apply a default timeout for all calls unless overridden
- test default timeout injection and CA bundle precedence
- launch Python via `cmd` inside PowerShell to avoid false `NativeCommandError` messages and update docs for the log path

## Testing
- `pytest -q`
- `python diagnose_ssl.py` *(fails: Error fetching certificate: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae046950c8832fab70f5b462105d28